### PR TITLE
feat: 프로필 페이지 팔로워 팔로잉 api 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,14 +23,7 @@ export default function App() {
           <Route path="/profile:id" element={<ProfileLayout />}>
             <Route index path="posts" element={<MyThreadsList />} />
             <Route path="follower" element={<FollowBox title={"팔로워"} />} />
-            <Route
-              path="following"
-              element={<FollowBox title={"팔로잉"} />}
-            ></Route>
-            <Route
-              path="following"
-              element={<FollowBox title={"팔로잉"} />}
-            ></Route>
+            <Route path="following" element={<FollowBox title={"팔로잉"} />} />
             <Route path="modify" element={<EditProfile />}></Route>
           </Route>
           <Route path="/fanpage/:teamName/:channelId" element={<FanPage />} />

--- a/src/components/Profile/FollowBox.tsx
+++ b/src/components/Profile/FollowBox.tsx
@@ -1,18 +1,44 @@
+import { useEffect, useRef, useState, useTransition } from "react";
+import { axiosInstance } from "../../api/axiosInstance";
 import FollowCard from "./FollowCard";
 import { LuUserCheck } from "react-icons/lu";
+import { ExtendedUser, Follow } from "../../types/postType";
+import useGetUser from "./useGetUser";
 
-const users = [
-  {
-    name: "username1",
-    isOnline: true,
-  },
-  {
-    name: "username2",
-    isOnline: false,
-  },
-];
+const USERID = "681c62cf1fef464281ee7341";
 
 export default function FollowBox({ title }: { title: string }) {
+  const [followUsers, setFollowUsers] = useState<ExtendedUser[]>();
+  const followingIds = useRef<string[]>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const user = useGetUser(USERID);
+
+  useEffect(() => {
+    if (!user) return;
+
+    const ids: string[] =
+      title === "팔로워" ? user.followers.map((f: Follow) => f.follower) : user.following.map((f: Follow) => f.user);
+
+    followingIds.current = user.following.map((f: Follow) => f.user);
+
+    const getUsers = async () => {
+      try {
+        const results = await Promise.all(ids.map((id) => axiosInstance.get(`/users/${id}`)));
+        const users = results.map((res) => res.data);
+        setFollowUsers(users);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+
+    startTransition(async () => {
+      await getUsers();
+    });
+  }, [user, title]);
+
+  if (isPending) <h1>Loading...</h1>;
+
   return (
     <div className="h-[550px] flex flex-col items-center p-[27px] rounded-[10px] border border-[#d9d9d9] shadow-md w-full max-w-[1200px] lg:px-[7%] md:px-[27%]">
       <div className="flex items-center self-start text-[20px] font-bold mb-[20px]">
@@ -20,9 +46,21 @@ export default function FollowBox({ title }: { title: string }) {
         모든 {title}
       </div>
       <div className="grid lg:grid-cols-2 md:grid-cols-1 lg:gap-x-[100px] gap-y-[8px]">
-        {users.map((user) => (
-          <FollowCard name={user.name} isOnline={user.isOnline} />
-        ))}
+        {title === "팔로워"
+          ? followUsers?.map((follow) => (
+              <FollowCard
+                name={follow.username ? follow.username : follow.fullName}
+                isOnline={follow.isOnline}
+                isFollowing={followingIds.current?.includes(follow._id) ?? false}
+              />
+            ))
+          : followUsers?.map((follow) => (
+              <FollowCard
+                name={follow.username ? follow.username : follow.fullName}
+                isOnline={follow.isOnline}
+                isFollowing={true}
+              />
+            ))}
       </div>
     </div>
   );

--- a/src/components/Profile/FollowCard.tsx
+++ b/src/components/Profile/FollowCard.tsx
@@ -1,12 +1,20 @@
 import { FaUserCircle } from "react-icons/fa";
 import { twMerge } from "tailwind-merge";
 
-export default function FollowCard({ name, isOnline }: { name: string; isOnline: boolean }) {
+export default function FollowCard({
+  name,
+  isOnline,
+  isFollowing,
+}: {
+  name: string;
+  isOnline: boolean;
+  isFollowing: boolean;
+}) {
   return (
     <>
       <div className="flex items-center border border-[#335CB3] dark:border-[#FFFFFF] rounded-[10px] w-[470px] h-[63px] justify-between px-[13px] my-[5px]">
         <div className="relative w-[34px] h-[34px]">
-          <FaUserCircle className="absolute w-full h-full fill-[#0033A0] dark:fill-[#FFFFFF]"/>
+          <FaUserCircle className="absolute w-full h-full fill-[#0033A0] dark:fill-[#FFFFFF]" />
           <div
             className={twMerge(
               "absolute w-[8px] h-[8px] right-[1px] rounded-[100px] bg-[#00FF1E] dark:border dark:border-[#0033A0]",
@@ -18,9 +26,16 @@ export default function FollowCard({ name, isOnline }: { name: string; isOnline:
         <button className="w-[100px] h-[24px] text-[14px] rounded-[10px] bg-[#0033A0] text-[#ffffff] cursor-pointer">
           쪽지 보내기
         </button>
-        <button className="w-[100px] h-[24px] text-[14px] rounded-[10px] bg-[#C5585F] text-[#ffffff] cursor-pointer">
-          팔로우 취소
-        </button>
+        {isFollowing ? (
+          <button className="w-[100px] h-[24px] text-[14px] rounded-[10px] bg-[#C5585F] text-[#ffffff] cursor-pointer">
+            팔로우 취소
+          </button>
+        ) : (
+          <button className="w-[100px] h-[24px] text-[14px] rounded-[10px] bg-[#C5585F] text-[#ffffff] cursor-pointer">
+            팔로우
+          </button>
+        )}
+
         <div></div>
       </div>
     </>

--- a/src/components/Profile/useGetUser.ts
+++ b/src/components/Profile/useGetUser.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState, useTransition } from "react";
+import { ExtendedUser } from "../../types/postType";
+import { axiosInstance } from "../../api/axiosInstance";
+
+export default function useGetUser(userId: string) {
+  const [user, setUser] = useState<ExtendedUser>();
+  const [, startTransition] = useTransition();
+
+  const getHandler = async () => {
+    try {
+      const { data } = await axiosInstance.get(`/users/${userId}`);
+      setUser(data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  useEffect(() => {
+    startTransition(async () => {
+      await getHandler();
+    });
+  }, []);
+
+  return user;
+}

--- a/src/layout/ProfileLayout.tsx
+++ b/src/layout/ProfileLayout.tsx
@@ -1,37 +1,14 @@
 import { NavLink, Outlet, useParams } from "react-router";
 import profile from "../assets/images/bears.png";
 import mascot from "../assets/images/doosan_mascot.png";
-import { axiosInstance } from "../api/axiosInstance";
-import { useEffect, useState, useTransition } from "react";
-import { ExtendedUser } from "../types/postType";
+import useGetUser from "../components/Profile/useGetUser";
 
-const USERNAME = "User name";
-const POSTNUM = 10;
-const FOLLOWERNUM = 200;
-const FOLLOWINGNUM = 100;
-const MESSAGENUM = 12;
 const USERID = "681c62cf1fef464281ee7341"; // params.id
 
 export default function ProfileLayout() {
-  const [user, setUser] = useState<ExtendedUser>();
-  const [isPending, startTransition] = useTransition();
   const params = useParams();
 
-  const getHandler = async () => {
-    try {
-      const { data } = await axiosInstance.get(`/users/${USERID}`);
-      console.log(data);
-      setUser(data);
-    } catch (e) {
-      console.log(e);
-    }
-  };
-
-  useEffect(() => {
-    startTransition(async () => {
-      await getHandler();
-    });
-  }, []);
+  const user = useGetUser(USERID);
 
   return (
     <div className="flex flex-col gap-[34px] w-full max-w-[1200px] mx-auto mt-[40px]">

--- a/src/types/postType.ts
+++ b/src/types/postType.ts
@@ -18,8 +18,8 @@ export interface BaseUser {
   posts: string[];
   likes: string[];
   comments: string[];
-  followers: string[];
-  following: string[];
+  followers: Follow[];
+  following: Follow[];
   notifications: string[];
   messages: string[];
   createdAt: string;
@@ -33,6 +33,15 @@ export interface ExtendedUser extends BaseUser {
   coverImagePublicId?: string;
   image?: string;
   imagePublicId?: string;
+}
+
+export interface Follow {
+  _id: string;
+  user: string;
+  follower: string;
+  createdAt: string;
+  updatedAt: string;
+  __v: number;
 }
 
 export interface Comment {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 프로필 페이지에서 팔로워 팔로잉 api를 연결했습니다.
  - 나를 팔로우하는 사람 중 내가 팔로우 하는 사람이면 '팔로우 취소' 버튼이, 팔로우 하지 않는 사람이면 '팔로우' 버튼이 노출됩니다.

### 스크린샷 (선택)
- 팔로워
<img width="1385" alt="image" src="https://github.com/user-attachments/assets/5f809969-53c0-468c-8f8c-a65be91be4dc" />

- 팔로잉
<img width="1385" alt="image" src="https://github.com/user-attachments/assets/9f87c613-9b77-4ac0-a1ab-1b57141e9db3" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
