### PR TITLE
feat: 프로필 페이지 내 팔로워 팔로잉 box margin bottom 추가

### DIFF
--- a/src/components/Profile/FollowBox.tsx
+++ b/src/components/Profile/FollowBox.tsx
@@ -39,7 +39,7 @@ export default function FollowBox({ title }: { title: string }) {
   if (isPending) <h1>Loading...</h1>;
 
   return (
-    <div className="h-[550px] flex flex-col items-center p-[27px] rounded-[10px] border border-[#d9d9d9] shadow-md w-full max-w-[1200px] lg:px-[7%] md:px-[27%]">
+    <div className="h-[550px] flex flex-col items-center p-[27px] rounded-[10px] border border-[#d9d9d9] shadow-md w-full max-w-[1200px] lg:px-[7%] md:px-[27%] mb-[40px]">
       <div className="flex items-center self-start text-[20px] font-bold mb-[20px]">
         <LuUserCheck size={26} className="mr-[11px]" />
         모든 {title}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 프로필 페이지 내 팔로워 팔로잉 box에도 margin bottom을 추가했습니다.

### 스크린샷 (선택)
<img width="1619" alt="image" src="https://github.com/user-attachments/assets/a301e017-2569-47a1-9775-257db7e26c88" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
