### PR TITLE
feat: 프로필 페이지 프로필 이미지 대체 및 top 버튼 추가

### DIFF
--- a/src/components/Profile/EmptyContent.tsx
+++ b/src/components/Profile/EmptyContent.tsx
@@ -1,0 +1,13 @@
+export interface EmptyMessageProps {
+  message: string;
+}
+
+export default function EmptyContent({ imgSrc, message }: EmptyMessageProps) {
+  return (
+    <>
+      <div className="flex flex-col justify-center text-gray-400">
+        <p className="text-lg">{message}</p>
+      </div>
+    </>
+  );
+}

--- a/src/components/Profile/FollowBox.tsx
+++ b/src/components/Profile/FollowBox.tsx
@@ -3,6 +3,7 @@ import { LuUserCheck } from "react-icons/lu";
 import useGetUser from "./useGetUser";
 import { useParams } from "react-router";
 import { BaseUser } from "../../types/postType";
+import EmptyContent from "./EmptyContent";
 
 export default function FollowBox({ isFollower }: { isFollower: boolean }) {
   const params = useParams();
@@ -15,13 +16,25 @@ export default function FollowBox({ isFollower }: { isFollower: boolean }) {
         {isFollower ? "모든 팔로워" : "모든 팔로잉"}
       </div>
       <div className="grid lg:grid-cols-2 md:grid-cols-1 lg:gap-x-[100px] gap-y-[8px]">
-        {isFollower
-          ? user?.followers.map((follow) => (
+        {isFollower ? (
+          user?.followers && user?.followers.length > 0 ? (
+            user?.followers.map((follow) => (
               <FollowCard key={follow._id} followId={follow.follower} profileId={follow.user} />
             ))
-          : user?.following.map((follow) => (
-              <FollowCard key={follow._id} followId={follow.user} profileId={follow.follower} />
-            ))}
+          ) : (
+            <div className="col-span-full flex justify-center items-center h-[400px]">
+              <EmptyContent message="팔로워 목록이 비었습니다" />
+            </div>
+          )
+        ) : user?.following && user?.following.length > 0 ? (
+          user?.following.map((follow) => (
+            <FollowCard key={follow._id} followId={follow.user} profileId={follow.follower} />
+          ))
+        ) : (
+          <div className="col-span-full flex justify-center items-center h-[400px]">
+            <EmptyContent message="팔로잉 목록이 비었습니다" />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Profile/MyThreadsList.tsx
+++ b/src/components/Profile/MyThreadsList.tsx
@@ -4,6 +4,7 @@ import { Post } from "../../types/postType";
 import Threads from "../FanPage/Threads";
 import { useParams } from "react-router";
 import { refreshStore } from "../../stores/refreshStore";
+import EmptyContent from "./EmptyContent";
 
 export default function MyThreadsList() {
   const [myPosts, setMyPosts] = useState<Post[]>([]);
@@ -31,37 +32,43 @@ export default function MyThreadsList() {
   return (
     <div className="flex flex-col gap-6 mb-[40px]">
       {/* 피드들 */}
-      {myPosts?.map((post) => {
-        let postTitle = "";
-        let postContent = "";
+      {myPosts.length > 0 ? (
+        myPosts?.map((post) => {
+          let postTitle = "";
+          let postContent = "";
 
-        try {
-          const parsedTitle = JSON.parse(post.title);
-          postTitle = parsedTitle[0].postTitle;
-          postContent = parsedTitle[0].postContent;
-        } catch (e) {
-          console.error("파싱실패", e);
-        }
+          try {
+            const parsedTitle = JSON.parse(post.title);
+            postTitle = parsedTitle[0].postTitle;
+            postContent = parsedTitle[0].postContent;
+          } catch (e) {
+            console.error("파싱실패", e);
+          }
 
-        const likeChecked = post.likes.some((like) => like.user === params.id);
+          const likeChecked = post.likes.some((like) => like.user === params.id);
 
-        return (
-          <Threads
-            key={post._id}
-            postId={post._id}
-            username={post.author?.username ?? post.author?.fullName}
-            postUserId={post.author._id}
-            title={postTitle}
-            content={postContent}
-            date={new Date(post.createdAt).toLocaleDateString()}
-            channel={post.channel.name}
-            images={post.image ? [post.image] : []}
-            likes={post.likes}
-            comments={post.comments}
-            likeChecked={likeChecked}
-          />
-        );
-      })}
+          return (
+            <Threads
+              key={post._id}
+              postId={post._id}
+              username={post.author?.username ?? post.author?.fullName}
+              postUserId={post.author._id}
+              title={postTitle}
+              content={postContent}
+              date={new Date(post.createdAt).toLocaleDateString()}
+              channel={post.channel.name}
+              images={post.image ? [post.image] : []}
+              likes={post.likes}
+              comments={post.comments}
+              likeChecked={likeChecked}
+            />
+          );
+        })
+      ) : (
+        <div className="h-[550px] border border-[#d9d9d9] shadow-md px-[27px] rounded-[10px] flex justify-center">
+          <EmptyContent message="게시물을 작성해보세요"></EmptyContent>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/layout/ProfileLayout.tsx
+++ b/src/layout/ProfileLayout.tsx
@@ -2,10 +2,35 @@ import { NavLink, Outlet, useParams } from "react-router";
 import mascot from "../assets/images/doosan_mascot.png";
 import useGetUser from "../components/Profile/useGetUser";
 import ProfileImage from "../components/FanPage/ProfileImage";
+import { useEffect, useState } from "react";
 
 export default function ProfileLayout() {
   const params = useParams();
   const user = useGetUser(params.id!);
+
+  const [isVisible, setIsVisible] = useState(false);
+
+  // 스크롤 이벤트
+  useEffect(() => {
+    const handleScroll = () => {
+      if (window.scrollY > 300) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  // 최상단으로 스크롤 이동
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
 
   return (
     <div className="flex flex-col gap-[34px] w-full max-w-[1200px] mx-auto mt-[40px]">
@@ -76,6 +101,14 @@ export default function ProfileLayout() {
         />
       </div>
       <Outlet></Outlet>
+      {isVisible && (
+        <button
+          onClick={scrollToTop}
+          className="fixed bottom-6 right-6 md:bottom-10 md:right-20 p-3 bg-blue-600 text-white rounded-[10px] shadow-lg hover:bg-blue-700 transition-all"
+        >
+          TOP
+        </button>
+      )}
     </div>
   );
 }

--- a/src/layout/ProfileLayout.tsx
+++ b/src/layout/ProfileLayout.tsx
@@ -1,6 +1,7 @@
 import { NavLink, Outlet, useParams } from "react-router";
 import mascot from "../assets/images/doosan_mascot.png";
 import useGetUser from "../components/Profile/useGetUser";
+import ProfileImage from "../components/FanPage/ProfileImage";
 
 export default function ProfileLayout() {
   const params = useParams();
@@ -9,11 +10,16 @@ export default function ProfileLayout() {
   return (
     <div className="flex flex-col gap-[34px] w-full max-w-[1200px] mx-auto mt-[40px]">
       <div className="border border-[#D9D9D9] shadow-md rounded-[10px] lg:h-[200px] md:h-[154px] sm:h-[120px] flex items-center gap-[50px] justify-between lg:px-[110px] px-[80px]">
-        <img
-          className="lg:w-[123px] lg:h-[123px] md:w-[100px] md:h-[100px] sm:w-[60px] sm:h-[60px]"
-          src={user?.image}
-          alt="my profile"
-        />
+        {user?.image ? (
+          <img
+            className="lg:w-[123px] lg:h-[123px] md:w-[100px] md:h-[100px] sm:w-[60px] sm:h-[60px]"
+            src={user?.image}
+            alt="my profile"
+          />
+        ) : (
+          <ProfileImage size={90} />
+        )}
+
         <div className="">
           <div className="md:text-[24px] font-bold sm:text-[10px]">
             {user?.username ? user?.username : user?.fullName}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 프로필 페이지에서 프로필 이미지가 없을 경우 프로필 아이콘으로 대체됩니다.
- 스크롤시 최상단으로 바로 이동할 수 있는 top 버튼이 추가되었습니다.

### 스크린샷 (선택)
<img width="1509" alt="image" src="https://github.com/user-attachments/assets/b4727979-4335-489f-a4ba-f1c8b34a2b57" />
<img width="1479" alt="image" src="https://github.com/user-attachments/assets/4bc744ff-d6c7-4fe1-addc-33639beae2c8" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
