### PR TITLE
feat: 팬페이지에서 다른 유저 프로필 카드 구현

### DIFF
--- a/src/components/FanPage/SimpleProfileCard.tsx
+++ b/src/components/FanPage/SimpleProfileCard.tsx
@@ -6,6 +6,7 @@ import { axiosInstance } from "../../api/axiosInstance";
 import { ExtendedUser, Follow } from "../../types/postType";
 import { refreshStore } from "../../stores/refreshStore";
 import useGetUser from "../Profile/useGetUser";
+import { Link } from "react-router";
 
 interface ProfileCardProps {
   loginUserId: string;
@@ -50,37 +51,39 @@ export default function SimpleProfileCard({ loginUserId, author }: ProfileCardPr
   return (
     <div className="w-full max-w-[285px] bg-[#F5F5F5] dark:bg-gray-900 mx-auto shadow-md rounded-[10px] border-2 border-[#d9d9d9] p-4 flex items-center gap-6">
       {/* 프로필 이미지 */}
-      <div className="flex flex-col items-center gap-1">
-        <div className="border border-[#d9d9d9] rounded-full bg-[#0033A0] flex items-center justify-center">
-          {author.image ? (
-            <div className="relative w-[60px] h-[60px]">
-              <img src={author.image} alt="profile" className="w-full h-full rounded-full" />
-              <div
-                className={twMerge(
-                  "absolute w-[9px] h-[9px] right-[1px] top-[5px] rounded-[100px] bg-[#00FF1E] dark:border dark:border-[#0033A0]",
-                  !author.isOnline && "hidden"
-                )}
-              />
-            </div>
-          ) : (
-            <div className="relative w-[60px] h-[60px]">
-              <ProfileImage size={60} />
-              <div
-                className={twMerge(
-                  "absolute w-[9px] h-[9px] right-[1px] top-[5px] rounded-[100px] bg-[#00FF1E] dark:border dark:border-[#0033A0]",
-                  !author.isOnline && "hidden"
-                )}
-              />
-            </div>
-          )}
+      <Link to={`/profile/${author._id}/posts`}>
+        <div className="flex flex-col items-center gap-1">
+          <div className="border border-[#d9d9d9] rounded-full bg-[#0033A0] flex items-center justify-center">
+            {author.image ? (
+              <div className="relative w-[60px] h-[60px]">
+                <img src={author.image} alt="profile" className="w-full h-full rounded-full" />
+                <div
+                  className={twMerge(
+                    "absolute w-[9px] h-[9px] right-[1px] top-[5px] rounded-[100px] bg-[#00FF1E] dark:border dark:border-[#0033A0]",
+                    !author.isOnline && "hidden"
+                  )}
+                />
+              </div>
+            ) : (
+              <div className="relative w-[60px] h-[60px]">
+                <ProfileImage size={60} />
+                <div
+                  className={twMerge(
+                    "absolute w-[9px] h-[9px] right-[1px] top-[5px] rounded-[100px] bg-[#00FF1E] dark:border dark:border-[#0033A0]",
+                    !author.isOnline && "hidden"
+                  )}
+                />
+              </div>
+            )}
+          </div>
+          <div className="text-[12px] text-center font-bold">{author.username ? author.username : author.fullName}</div>
         </div>
-        <div className="text-[12px] text-center font-bold">{author.username ? author.username : author.fullName}</div>
-      </div>
+      </Link>
 
       {/* 사용자 정보 */}
       <div className="flex flex-col flex-grow gap-2">
         {/* 통계 정보 */}
-        <div className="flex gap-3 text-[10px] cursor-pointer">
+        <div className="flex gap-3 text-[10px]">
           {stats.map(({ id, label, count }) => (
             <span
               key={id}
@@ -94,19 +97,21 @@ export default function SimpleProfileCard({ loginUserId, author }: ProfileCardPr
         </div>
 
         {author._id === loginUserId ? (
-          <button className="px-4 py-1 rounded-[6px] border bg-[#fff] border-[#d6d6d6] text-[10px] text-[#333] hover:bg-[#0033a0] hover:text-[#fff] transition">
-            내 프로필 가기
-          </button>
+          <Link to={`/profile/${loginUserId}/posts`} onClick={() => window.scrollTo(0, 0)}>
+            <button className="px-4 py-1 rounded-[6px] border bg-[#fff] border-[#d6d6d6] text-[10px] text-[#333] hover:bg-[#0033a0] hover:text-[#fff] transition cursor-pointer">
+              내 프로필 가기
+            </button>
+          </Link>
         ) : following ? (
           <button
-            className="px-4 py-1 rounded-[6px] border bg-[#fff] border-[#d6d6d6] text-[10px] text-[#333] hover:bg-[#0033a0] hover:text-[#fff] transition"
+            className="px-4 py-1 rounded-[6px] border bg-[#fff] border-[#d6d6d6] text-[10px] text-[#333] hover:bg-[#0033a0] hover:text-[#fff] transition cursor-pointer"
             onClick={unfollowHandler}
           >
             팔로우 취소
           </button>
         ) : (
           <button
-            className="px-4 py-1 rounded-[6px] border bg-[#fff] border-[#d6d6d6] text-[10px] text-[#333] hover:bg-[#0033a0] hover:text-[#fff] transition"
+            className="px-4 py-1 rounded-[6px] border bg-[#fff] border-[#d6d6d6] text-[10px] text-[#333] hover:bg-[#0033a0] hover:text-[#fff] transition cursor-pointer"
             onClick={followHandler}
           >
             팔로우

--- a/src/components/FanPage/SimpleProfileCard.tsx
+++ b/src/components/FanPage/SimpleProfileCard.tsx
@@ -1,6 +1,25 @@
 import { useState } from "react";
+import ProfileImage from "./ProfileImage";
+import { FaUserCircle } from "react-icons/fa";
+import { twMerge } from "tailwind-merge";
 
-export default function SimpleProfileCard() {
+interface ProfileCardProps {
+  userId: string;
+  username: string;
+  profileImage?: string;
+  isOnline: boolean;
+  followerNum: number;
+  followingNum: number;
+}
+
+export default function SimpleProfileCard({
+  userId,
+  username,
+  profileImage,
+  isOnline,
+  followerNum,
+  followingNum,
+}: ProfileCardProps) {
   const [activeTab, setActiveTab] = useState("posts");
 
   const stats = [
@@ -9,18 +28,36 @@ export default function SimpleProfileCard() {
     { id: "following", label: "팔로잉", count: 10 },
   ];
 
+  console.log(isOnline);
+
   return (
     <div className="w-full max-w-[285px] bg-[#F5F5F5] dark:bg-gray-900 mx-auto shadow-md rounded-[10px] border-2 border-[#d9d9d9] p-4 flex items-center gap-6">
       {/* 프로필 이미지 */}
       <div className="flex flex-col items-center gap-1">
-        <div className="w-[60px] border border-[#d9d9d9] h-[60px] rounded-full bg-[#0033A0] flex items-center justify-center overflow-hidden">
-          <img
-            src="https://www.doosanbears.com/_next/image?url=%2Fimages%2Fimg_symbol_2025_1.jpg&w=256&q=75"
-            alt="profile"
-            className="object-contain w-full h-full"
-          />
+        <div className="border border-[#d9d9d9] rounded-full bg-[#0033A0] flex items-center justify-center">
+          {profileImage ? (
+            <div className="relative w-[60px] h-[60px]">
+              <img src={profileImage} alt="profile" className="w-full h-full rounded-full" />
+              <div
+                className={twMerge(
+                  "absolute w-[9px] h-[9px] right-[1px] top-[5px] rounded-[100px] bg-[#00FF1E] dark:border dark:border-[#0033A0]",
+                  !isOnline && "hidden"
+                )}
+              />
+            </div>
+          ) : (
+            <div className="relative w-[60px] h-[60px]">
+              <ProfileImage size={60} />
+              <div
+                className={twMerge(
+                  "absolute w-[9px] h-[9px] right-[1px] top-[5px] rounded-[100px] bg-[#00FF1E] dark:border dark:border-[#0033A0]",
+                  !isOnline && "hidden"
+                )}
+              />
+            </div>
+          )}
         </div>
-        <div className="text-[12px] text-center font-bold">User name</div>
+        <div className="text-[12px] text-center font-bold">{username}</div>
       </div>
 
       {/* 사용자 정보 */}
@@ -31,11 +68,7 @@ export default function SimpleProfileCard() {
             <span
               key={id}
               onClick={() => setActiveTab(id)}
-              className={`font-semibold ${
-                activeTab === id
-                  ? "text-[#FF8A00]"
-                  : `text-[#0033a0] dark:text-white`
-              }`}
+              className={`font-semibold ${activeTab === id ? "text-[#FF8A00]" : `text-[#0033a0] dark:text-white`}`}
             >
               {label} {count}
             </span>

--- a/src/components/FanPage/SimpleProfileCard.tsx
+++ b/src/components/FanPage/SimpleProfileCard.tsx
@@ -2,48 +2,63 @@ import { useState } from "react";
 import ProfileImage from "./ProfileImage";
 import { FaUserCircle } from "react-icons/fa";
 import { twMerge } from "tailwind-merge";
+import { axiosInstance } from "../../api/axiosInstance";
+import { ExtendedUser, Follow } from "../../types/postType";
+import { refreshStore } from "../../stores/refreshStore";
+import useGetUser from "../Profile/useGetUser";
 
 interface ProfileCardProps {
-  userId: string;
-  username: string;
-  profileImage?: string;
-  isOnline: boolean;
-  postsNum: number;
-  followerNum: number;
-  followingNum: number;
+  loginUserId: string;
+  author: ExtendedUser;
 }
 
-export default function SimpleProfileCard({
-  userId,
-  username,
-  profileImage,
-  isOnline,
-  postsNum,
-  followerNum,
-  followingNum,
-}: ProfileCardProps) {
-  const [activeTab, setActiveTab] = useState("posts");
+export default function SimpleProfileCard({ loginUserId, author }: ProfileCardProps) {
+  // const [activeTab, setActiveTab] = useState("posts");
+  const refetch = refreshStore((state) => state.refetch);
+  const authorDetails = useGetUser(author._id);
 
   const stats = [
-    { id: "posts", label: "게시물", count: postsNum },
-    { id: "followers", label: "팔로워", count: followerNum },
-    { id: "following", label: "팔로잉", count: followingNum },
+    { id: "posts", label: "게시물", count: author.posts.length },
+    { id: "followers", label: "팔로워", count: author.followers.length },
+    { id: "following", label: "팔로잉", count: author.following.length },
   ];
 
-  console.log(isOnline);
+  const following = authorDetails?.followers.find((follow) => follow.follower === loginUserId);
+
+  const unfollowHandler = async () => {
+    try {
+      const { data } = await axiosInstance.delete<Follow>("follow/delete", {
+        data: { id: following?._id },
+      });
+      refetch();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const followHandler = async () => {
+    try {
+      const { data } = await axiosInstance.post<Follow>("follow/create", {
+        userId: author._id,
+      });
+      refetch();
+    } catch (e) {
+      console.error(e);
+    }
+  };
 
   return (
     <div className="w-full max-w-[285px] bg-[#F5F5F5] dark:bg-gray-900 mx-auto shadow-md rounded-[10px] border-2 border-[#d9d9d9] p-4 flex items-center gap-6">
       {/* 프로필 이미지 */}
       <div className="flex flex-col items-center gap-1">
         <div className="border border-[#d9d9d9] rounded-full bg-[#0033A0] flex items-center justify-center">
-          {profileImage ? (
+          {author.image ? (
             <div className="relative w-[60px] h-[60px]">
-              <img src={profileImage} alt="profile" className="w-full h-full rounded-full" />
+              <img src={author.image} alt="profile" className="w-full h-full rounded-full" />
               <div
                 className={twMerge(
                   "absolute w-[9px] h-[9px] right-[1px] top-[5px] rounded-[100px] bg-[#00FF1E] dark:border dark:border-[#0033A0]",
-                  !isOnline && "hidden"
+                  !author.isOnline && "hidden"
                 )}
               />
             </div>
@@ -53,13 +68,13 @@ export default function SimpleProfileCard({
               <div
                 className={twMerge(
                   "absolute w-[9px] h-[9px] right-[1px] top-[5px] rounded-[100px] bg-[#00FF1E] dark:border dark:border-[#0033A0]",
-                  !isOnline && "hidden"
+                  !author.isOnline && "hidden"
                 )}
               />
             </div>
           )}
         </div>
-        <div className="text-[12px] text-center font-bold">{username}</div>
+        <div className="text-[12px] text-center font-bold">{author.username ? author.username : author.fullName}</div>
       </div>
 
       {/* 사용자 정보 */}
@@ -78,9 +93,25 @@ export default function SimpleProfileCard({
           ))}
         </div>
 
-        <button className="px-4 py-1 rounded-[6px] border bg-[#fff] border-[#d6d6d6] text-[10px] text-[#333] hover:bg-[#0033a0] hover:text-[#fff] transition">
-          팔로우
-        </button>
+        {author._id === loginUserId ? (
+          <button className="px-4 py-1 rounded-[6px] border bg-[#fff] border-[#d6d6d6] text-[10px] text-[#333] hover:bg-[#0033a0] hover:text-[#fff] transition">
+            내 프로필 가기
+          </button>
+        ) : following ? (
+          <button
+            className="px-4 py-1 rounded-[6px] border bg-[#fff] border-[#d6d6d6] text-[10px] text-[#333] hover:bg-[#0033a0] hover:text-[#fff] transition"
+            onClick={unfollowHandler}
+          >
+            팔로우 취소
+          </button>
+        ) : (
+          <button
+            className="px-4 py-1 rounded-[6px] border bg-[#fff] border-[#d6d6d6] text-[10px] text-[#333] hover:bg-[#0033a0] hover:text-[#fff] transition"
+            onClick={followHandler}
+          >
+            팔로우
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/FanPage/SimpleProfileCard.tsx
+++ b/src/components/FanPage/SimpleProfileCard.tsx
@@ -8,6 +8,7 @@ interface ProfileCardProps {
   username: string;
   profileImage?: string;
   isOnline: boolean;
+  postsNum: number;
   followerNum: number;
   followingNum: number;
 }
@@ -17,15 +18,16 @@ export default function SimpleProfileCard({
   username,
   profileImage,
   isOnline,
+  postsNum,
   followerNum,
   followingNum,
 }: ProfileCardProps) {
   const [activeTab, setActiveTab] = useState("posts");
 
   const stats = [
-    { id: "posts", label: "게시물", count: 10 },
-    { id: "followers", label: "팔로워", count: 10 },
-    { id: "following", label: "팔로잉", count: 10 },
+    { id: "posts", label: "게시물", count: postsNum },
+    { id: "followers", label: "팔로워", count: followerNum },
+    { id: "following", label: "팔로잉", count: followingNum },
   ];
 
   console.log(isOnline);
@@ -67,8 +69,9 @@ export default function SimpleProfileCard({
           {stats.map(({ id, label, count }) => (
             <span
               key={id}
-              onClick={() => setActiveTab(id)}
-              className={`font-semibold ${activeTab === id ? "text-[#FF8A00]" : `text-[#0033a0] dark:text-white`}`}
+              className="dark:text-white text-[10px]"
+              // onClick={() => setActiveTab(id)}
+              // className={`font-semibold ${activeTab === id ? "text-[#FF8A00]" : `text-[#0033a0] dark:text-white`}`}
             >
               {label} {count}
             </span>

--- a/src/components/FanPage/Threads.tsx
+++ b/src/components/FanPage/Threads.tsx
@@ -19,6 +19,7 @@ interface ThreadProps {
   postUserId: string;
   postUserImage?: string;
   postUserIsOnline: boolean;
+  postUserPostsNum: number;
   postUserFollowersNum: number;
   postUserFollowingNum: number;
   title: string;
@@ -37,6 +38,7 @@ export default function Threads({
   username,
   postUserImage,
   postUserIsOnline,
+  postUserPostsNum,
   postUserFollowersNum,
   postUserFollowingNum,
   title,
@@ -208,7 +210,7 @@ ThreadProps) {
           <ProfileBlock username={username} />
           {showed && (
             <div className="absolute z-50 w-[285px] top-5 left-[90px]">
-              <SimpleProfileCard userId={postUserId} username={username} profileImage={postUserImage} isOnline={postUserIsOnline} followerNum={postUserFollowersNum} followingNum={postUserFollowingNum} />
+              <SimpleProfileCard userId={postUserId} username={username} profileImage={postUserImage} isOnline={postUserIsOnline} postsNum={postUserPostsNum} followerNum={postUserFollowersNum} followingNum={postUserFollowingNum} />
             </div>
           )}
         </div>

--- a/src/components/FanPage/Threads.tsx
+++ b/src/components/FanPage/Threads.tsx
@@ -9,7 +9,7 @@ import MyThreads from "./MyThreads";
 import Upload from "./Upload";
 import { AxiosError } from "axios";
 import { axiosInstance } from "../../api/axiosInstance";
-import { Like, Comment } from "../../types/postType";
+import { Like, Comment, Follow, ExtendedUser } from "../../types/postType";
 import { userStore } from "../../stores/userStore";
 import { useNavigate } from "react-router";
 import { refreshStore } from "../../stores/refreshStore";
@@ -17,11 +17,7 @@ interface ThreadProps {
   postId: string;
   username: string;
   postUserId: string;
-  postUserImage?: string;
-  postUserIsOnline: boolean;
-  postUserPostsNum: number;
-  postUserFollowersNum: number;
-  postUserFollowingNum: number;
+  author: ExtendedUser;
   title: string;
   content: string;
   date: string;
@@ -36,11 +32,7 @@ export default function Threads({
   postId,
   postUserId,
   username,
-  postUserImage,
-  postUserIsOnline,
-  postUserPostsNum,
-  postUserFollowersNum,
-  postUserFollowingNum,
+  author,
   title,
   content,
   date,
@@ -186,12 +178,7 @@ ThreadProps) {
 
   if (isEdit) {
     return (
-      <Upload
-        titleValue={title}
-        contentValue={content}
-        imageList={images}
-        editFinishHandler={editFinishHandler}
-      />
+      <Upload titleValue={title} contentValue={content} imageList={images} editFinishHandler={editFinishHandler} />
     );
   }
 
@@ -203,14 +190,11 @@ ThreadProps) {
       {/* 상단: 프로필 + 본문 */}
       <div className="flex gap-[25px]">
         {/* 왼쪽 고정 프로필 */}
-        <div
-          onMouseEnter={() => setShowed(true)}
-          onMouseLeave={() => setShowed(false)}
-        >
+        <div onMouseEnter={() => setShowed(true)} onMouseLeave={() => setShowed(false)}>
           <ProfileBlock username={username} />
           {showed && (
             <div className="absolute z-50 w-[285px] top-5 left-[90px]">
-              <SimpleProfileCard userId={postUserId} username={username} profileImage={postUserImage} isOnline={postUserIsOnline} postsNum={postUserPostsNum} followerNum={postUserFollowersNum} followingNum={postUserFollowingNum} />
+              <SimpleProfileCard loginUserId={userId} author={author} />
             </div>
           )}
         </div>
@@ -226,32 +210,17 @@ ThreadProps) {
           {images.length > 0 && (
             <div className="flex gap-2 flex-wrap mb-2">
               {images.map((src, index) => (
-                <img
-                  key={index}
-                  src={src}
-                  alt={`img-${index}`}
-                  className="w-[70%] rounded-[6px]"
-                />
+                <img key={index} src={src} alt={`img-${index}`} className="w-[70%] rounded-[6px]" />
               ))}
             </div>
           )}
           <div className="flex justify-between items-center text-[#ababab] text-[16px] mt-auto">
             <div className="flex items-center gap-4">
-              <button
-                className="flex items-center gap-1 hover:cursor-pointer"
-                onClick={toggleHeart}
-              >
-                {heart ? (
-                  <FaHeart className="text-[18px] text-red-500" />
-                ) : (
-                  <FaRegHeart className="text-[18px]" />
-                )}
+              <button className="flex items-center gap-1 hover:cursor-pointer" onClick={toggleHeart}>
+                {heart ? <FaHeart className="text-[18px] text-red-500" /> : <FaRegHeart className="text-[18px]" />}
                 {heartCount}
               </button>
-              <button
-                className="flex items-center gap-1 hover:cursor-pointer"
-                onClick={toggleShowComments}
-              >
+              <button className="flex items-center gap-1 hover:cursor-pointer" onClick={toggleShowComments}>
                 <FaRegComment className="text-[18px]" /> {commentList.length}
               </button>
             </div>
@@ -264,11 +233,7 @@ ThreadProps) {
 
       {showComments && (
         <div className="w-full overflow-hidden transition-all ease-in-out">
-          <Comments
-            postId={postId}
-            commentList={commentList}
-            setCommentList={setCommentList}
-          />
+          <Comments postId={postId} commentList={commentList} setCommentList={setCommentList} />
         </div>
       )}
     </div>

--- a/src/components/FanPage/Threads.tsx
+++ b/src/components/FanPage/Threads.tsx
@@ -17,6 +17,10 @@ interface ThreadProps {
   postId: string;
   username: string;
   postUserId: string;
+  postUserImage?: string;
+  postUserIsOnline: boolean;
+  postUserFollowersNum: number;
+  postUserFollowingNum: number;
   title: string;
   content: string;
   date: string;
@@ -25,13 +29,16 @@ interface ThreadProps {
   likes: Like[];
   comments: Comment[];
   likeChecked: boolean;
-  isMyThread?: boolean;
 }
 
 export default function Threads({
   postId,
   postUserId,
   username,
+  postUserImage,
+  postUserIsOnline,
+  postUserFollowersNum,
+  postUserFollowingNum,
   title,
   content,
   date,
@@ -201,7 +208,7 @@ ThreadProps) {
           <ProfileBlock username={username} />
           {showed && (
             <div className="absolute z-50 w-[285px] top-5 left-[90px]">
-              <SimpleProfileCard />
+              <SimpleProfileCard userId={postUserId} username={username} profileImage={postUserImage} isOnline={postUserIsOnline} followerNum={postUserFollowersNum} followingNum={postUserFollowingNum} />
             </div>
           )}
         </div>

--- a/src/components/FanPage/ThreadsList.tsx
+++ b/src/components/FanPage/ThreadsList.tsx
@@ -50,6 +50,10 @@ export default function ThreadsList() {
             postId={post._id}
             username={post.author?.username ?? post.author?.fullName}
             postUserId={post.author._id}
+            postUserImage={post.author.image}
+            postUserIsOnline={post.author.isOnline}
+            postUserFollowersNum={post.author.followers.length}
+            postUserFollowingNum={post.author.following.length}
             title={postTitle}
             content={postContent}
             date={new Date(post.createdAt).toLocaleDateString()}

--- a/src/components/FanPage/ThreadsList.tsx
+++ b/src/components/FanPage/ThreadsList.tsx
@@ -50,11 +50,7 @@ export default function ThreadsList() {
             postId={post._id}
             username={post.author?.username ?? post.author?.fullName}
             postUserId={post.author._id}
-            postUserImage={post.author.image}
-            postUserIsOnline={post.author.isOnline}
-            postUserPostsNum={post.author.posts.length}
-            postUserFollowersNum={post.author.followers.length}
-            postUserFollowingNum={post.author.following.length}
+            author={post.author}
             title={postTitle}
             content={postContent}
             date={new Date(post.createdAt).toLocaleDateString()}

--- a/src/components/FanPage/ThreadsList.tsx
+++ b/src/components/FanPage/ThreadsList.tsx
@@ -52,6 +52,7 @@ export default function ThreadsList() {
             postUserId={post.author._id}
             postUserImage={post.author.image}
             postUserIsOnline={post.author.isOnline}
+            postUserPostsNum={post.author.posts.length}
             postUserFollowersNum={post.author.followers.length}
             postUserFollowingNum={post.author.following.length}
             title={postTitle}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 팬페이지에서 다른 유저 프로필에 마우스 올리면 다른 유저 프로필 카드를 확인할 수 있습니다.
- 프로필 카드를 클릭하면 해당 유저 프로필 페이지로 이동합니다.
- 프로필 카드에서 해당 유저를 팔로우 또는 언팔로우 가능합니다.

### 스크린샷 (선택)
<img width="1409" alt="image" src="https://github.com/user-attachments/assets/0e9bca93-7afc-4d77-90e5-0a8a5b4d578a" />
<img width="1409" alt="image" src="https://github.com/user-attachments/assets/77361e38-227a-4acb-8464-a0bed7791e0b" />
<img width="1409" alt="image" src="https://github.com/user-attachments/assets/0511c836-e7d2-4f88-a3dc-c66d1b686987" />
<img width="1409" alt="image" src="https://github.com/user-attachments/assets/a15e9886-469a-430f-8eb7-4f35cb82cb36" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
