### PR TITLE
feat: 타 유저 프로필 페이지에서 내 팔로우 카드 쪽지 보내기 및 팔로우 버튼 숨김

### DIFF
--- a/src/components/FanPage/SimpleProfileCard.tsx
+++ b/src/components/FanPage/SimpleProfileCard.tsx
@@ -46,10 +46,14 @@ export default function SimpleProfileCard({ loginUserId, author }: ProfileCardPr
     }
   };
 
+  const navigateHandler = () => {
+    window.scrollTo(0, 0);
+  };
+
   return (
     <div className="w-full max-w-[285px] bg-[#F5F5F5] dark:bg-gray-900 mx-auto shadow-md rounded-[10px] border-2 border-[#d9d9d9] p-4 flex items-center gap-6">
       {/* 프로필 이미지 */}
-      <Link to={`/profile/${author._id}/posts`}>
+      <Link to={`/profile/${author._id}/posts`} onClick={navigateHandler}>
         <div className="flex flex-col items-center gap-1">
           <div className="border border-[#d9d9d9] rounded-full bg-[#0033A0] flex items-center justify-center">
             {author.image ? (
@@ -95,7 +99,7 @@ export default function SimpleProfileCard({ loginUserId, author }: ProfileCardPr
         </div>
 
         {author._id === loginUserId ? (
-          <Link to={`/profile/${loginUserId}/posts`} onClick={() => window.scrollTo(0, 0)}>
+          <Link to={`/profile/${loginUserId}/posts`} onClick={navigateHandler}>
             <button className="px-4 py-1 rounded-[6px] border bg-[#fff] border-[#d6d6d6] text-[10px] text-[#333] hover:bg-[#0033a0] hover:text-[#fff] transition cursor-pointer">
               내 프로필 가기
             </button>

--- a/src/components/Profile/FollowBox.tsx
+++ b/src/components/Profile/FollowBox.tsx
@@ -18,18 +18,14 @@ export default function FollowBox({ isFollower }: { isFollower: boolean }) {
       <div className="grid lg:grid-cols-2 md:grid-cols-1 lg:gap-x-[100px] gap-y-[8px]">
         {isFollower ? (
           user?.followers && user?.followers.length > 0 ? (
-            user?.followers.map((follow) => (
-              <FollowCard key={follow._id} followId={follow.follower} profileId={follow.user} />
-            ))
+            user?.followers.map((follow) => <FollowCard key={follow._id} followId={follow.follower} />)
           ) : (
             <div className="col-span-full flex justify-center items-center h-[400px]">
               <EmptyContent message="팔로워 목록이 비었습니다" />
             </div>
           )
         ) : user?.following && user?.following.length > 0 ? (
-          user?.following.map((follow) => (
-            <FollowCard key={follow._id} followId={follow.user} profileId={follow.follower} />
-          ))
+          user?.following.map((follow) => <FollowCard key={follow._id} followId={follow.user} />)
         ) : (
           <div className="col-span-full flex justify-center items-center h-[400px]">
             <EmptyContent message="팔로잉 목록이 비었습니다" />

--- a/src/components/Profile/FollowCard.tsx
+++ b/src/components/Profile/FollowCard.tsx
@@ -5,12 +5,14 @@ import { ExtendedUser, Follow } from "../../types/postType";
 import { axiosInstance } from "../../api/axiosInstance";
 import { refreshStore } from "../../stores/refreshStore";
 import { Link } from "react-router";
+import { userStore } from "../../stores/userStore";
 
-export default function FollowCard({ followId, profileId }: { followId: string; profileId: string }) {
+export default function FollowCard({ followId }: { followId: string }) {
   const userDetails: ExtendedUser | undefined = useGetUser(followId);
+  const loginUserId = userStore((state) => state.getUser()?._id);
   const refetch = refreshStore((state) => state.refetch);
 
-  const following = userDetails?.followers.find((follow) => follow.follower === profileId);
+  const following = userDetails?.followers.find((follow) => follow.follower === loginUserId);
 
   const unfollowHandler = async () => {
     try {
@@ -41,7 +43,7 @@ export default function FollowCard({ followId, profileId }: { followId: string; 
           {userDetails?.image ? (
             <img src={userDetails?.image} alt="profile image" className="absolute w-full h-full rounded-full" />
           ) : (
-            <FaUserCircle className="absolute w-full h-full fill-[#0033A0] dark:fill-[#FFFFFF]" />
+            <FaUserCircle className="absolute w-full h-full fill-[#2F6BEB] dark:fill-[#FFFFFF]" />
           )}
 
           <div
@@ -56,19 +58,30 @@ export default function FollowCard({ followId, profileId }: { followId: string; 
         </div>
       </Link>
 
-      <button className="w-[100px] h-[24px] text-[14px] rounded-[10px] bg-[#0033A0] text-[#ffffff] cursor-pointer">
+      <button
+        className={twMerge(
+          "w-[100px] h-[24px] text-[14px] rounded-[10px] bg-[#0033A0] text-[#ffffff] cursor-pointer",
+          followId === loginUserId && "hidden"
+        )}
+      >
         쪽지 보내기
       </button>
       {following ? (
         <button
-          className="w-[100px] h-[24px] text-[14px] rounded-[10px] bg-[#C5585F] text-[#ffffff] cursor-pointer"
+          className={twMerge(
+            "w-[100px] h-[24px] text-[14px] rounded-[10px] bg-[#C5585F] text-[#ffffff] cursor-pointer",
+            followId === loginUserId && "hidden"
+          )}
           onClick={unfollowHandler}
         >
           팔로우 취소
         </button>
       ) : (
         <button
-          className="w-[100px] h-[24px] text-[14px] rounded-[10px] bg-[#C5585F] text-[#ffffff] cursor-pointer"
+          className={twMerge(
+            "w-[100px] h-[24px] text-[14px] rounded-[10px] bg-[#C5585F] text-[#ffffff] cursor-pointer",
+            followId === loginUserId && "hidden"
+          )}
           onClick={followHandler}
         >
           팔로우

--- a/src/components/Profile/FollowCard.tsx
+++ b/src/components/Profile/FollowCard.tsx
@@ -60,7 +60,7 @@ export default function FollowCard({ followId }: { followId: string }) {
 
       <button
         className={twMerge(
-          "w-[100px] h-[24px] text-[14px] rounded-[10px] bg-[#0033A0] text-[#ffffff] cursor-pointer",
+          "w-[100px] h-[24px] text-[14px] rounded-[10px] bg-[#0033A0] dark:bg-[#2F6BEB] text-[#ffffff] cursor-pointer",
           followId === loginUserId && "hidden"
         )}
       >

--- a/src/components/Profile/FollowCard.tsx
+++ b/src/components/Profile/FollowCard.tsx
@@ -36,7 +36,7 @@ export default function FollowCard({ followId, profileId }: { followId: string; 
 
   return (
     <div className="flex items-center border border-[#335CB3] dark:border-[#FFFFFF] rounded-[10px] w-[470px] h-[63px] justify-between px-[13px] my-[5px]">
-      <Link to={`/profile/${userDetails?._id}/posts`} reloadDocument className="flex items-center">
+      <Link to={`/profile/${userDetails?._id}/posts`} className="flex items-center">
         <div className="relative w-[34px] h-[34px]">
           {userDetails?.image ? (
             <img src={userDetails?.image} alt="profile image" className="absolute w-full h-full rounded-full" />

--- a/src/components/Profile/MyThreadsList.tsx
+++ b/src/components/Profile/MyThreadsList.tsx
@@ -25,7 +25,7 @@ export default function MyThreadsList() {
     startTransition(async () => {
       await getHandler();
     });
-  }, [refresh]);
+  }, [refresh, params.id]);
 
   if (isPending) <h1>Loading...</h1>;
 

--- a/src/components/Profile/useGetUser.ts
+++ b/src/components/Profile/useGetUser.ts
@@ -21,7 +21,7 @@ export default function useGetUser(userId: string) {
     startTransition(async () => {
       await getHandler();
     });
-  }, [refresh]);
+  }, [refresh, userId]);
 
   return user;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 타 유저의 프로필 페이지에서 내 팔로우 카드의 쪽지 보내기 및 팔로우 버튼은 보여지지 않습니다.
- 프로필 페이지의 userid 변화를 감지하여 컴포넌트가 리렌더링 됩니다.

### 스크린샷 (선택)
<img width="1561" alt="image" src="https://github.com/user-attachments/assets/e850f31c-8e71-4428-ab05-0564d4a891f2" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
