### PR TITLE
fix: 메세지 전송 시 리스트, 팔로우 메세지 경로

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ export default function App() {
             <Route path="/message" element={<MessagePage />}>
               <Route index element={<EmptyMessage />} />
               <Route path="new" element={<NewMessage />} />
-              <Route path="/message/:id" element={<MessagePage />} />
+              <Route path="/message/:id" element={<MessageContainer />} />
             </Route>
             <Route path="profile/edit" element={<EditProfile />} />
           </Route>

--- a/src/components/Profile/FollowCard.tsx
+++ b/src/components/Profile/FollowCard.tsx
@@ -83,7 +83,7 @@ export default function FollowCard({ followId }: { followId: string }) {
         </div>
       </Link>
 
-      <Link to={`/message/${userDetails?._id}`}>
+      <Link to={`/message/${userDetails?._id}`} state={{ selectedUser: userDetails }}>
         <button
           className={twMerge(
             "w-[100px] h-[24px] text-[14px] rounded-[10px] bg-[#0033A0] dark:bg-[#2F6BEB] text-[#ffffff] cursor-pointer",

--- a/src/components/message/MessageContainer.tsx
+++ b/src/components/message/MessageContainer.tsx
@@ -4,16 +4,16 @@ import { MessageProps } from "../../types/messageType";
 import MessageChatView from "./MessageChatView";
 import { axiosInstance } from "../../api/axiosInstance";
 import { userStore } from "../../stores/userStore";
-import { useParams, useLocation } from "react-router";
+import { useLocation } from "react-router";
 import { ExtendedUser } from "../../types/postType";
 import EmptyMessage from "./EmptyMessage";
 
 export default function MessageContainer() {
   const [messages, setMessages] = useState<MessageProps[]>([]);
   const myId = userStore.getState().getUser()?._id;
-  const { id: selectedUserId } = useParams();
   const location = useLocation();
   const selectedUser = location.state?.selectedUser as ExtendedUser;
+  const selectedUserId = selectedUser._id;
 
   const fetchMessages = async () => {
     try {

--- a/src/components/message/SendMessageForm.tsx
+++ b/src/components/message/SendMessageForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import SendButton from "./SendButton";
 import { axiosInstance } from "../../api/axiosInstance";
+import { useMessageStore } from "../../stores/messageStore";
 
 export default function SendMessageForm({
   selectedUserId,
@@ -10,7 +11,6 @@ export default function SendMessageForm({
   onSend: () => void;
 }) {
   const [content, setContent] = useState("");
-
   const sendHandler = async () => {
     if (!content.trim()) return;
     try {
@@ -29,6 +29,7 @@ export default function SendMessageForm({
       });
       setContent("");
       onSend();
+      useMessageStore.getState().setRefetch();
     } catch (err) {
       console.error("메세지 보내기 실패", err);
     }
@@ -47,6 +48,9 @@ export default function SendMessageForm({
           value={content}
           onChange={(e) => setContent(e.target.value)}
           onKeyDown={(e) => {
+            if (e.nativeEvent.isComposing) {
+              return;
+            }
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
               sendHandler();

--- a/src/components/message/SideMessageList.tsx
+++ b/src/components/message/SideMessageList.tsx
@@ -3,11 +3,13 @@ import { MessageProps, Sender } from "../../types/messageType";
 import { axiosInstance } from "../../api/axiosInstance";
 import { userStore } from "../../stores/userStore";
 import { useNavigate } from "react-router";
+import { useMessageStore } from "../../stores/messageStore";
 
 export default function SideMessageList() {
   const [lists, setLists] = useState<MessageProps[]>([]);
   const myId = userStore.getState().getUser()?._id;
   const navigate = useNavigate();
+  const { refetch } = useMessageStore();
 
   const fetchMessageList = async () => {
     try {
@@ -45,7 +47,7 @@ export default function SideMessageList() {
 
   useEffect(() => {
     fetchMessageList();
-  }, []);
+  }, [refetch]);
 
   return (
     <>

--- a/src/pages/MessagePage.tsx
+++ b/src/pages/MessagePage.tsx
@@ -10,7 +10,7 @@ export default function MessagePage() {
             <MessageSidebar />
           </div>
 
-          <div className="flex-1 pl-6 ">
+          <div className="flex-1 pl-6">
             <Outlet />
           </div>
         </div>

--- a/src/stores/channelStore.ts
+++ b/src/stores/channelStore.ts
@@ -9,6 +9,7 @@ type ChannelStore = {
 
 export const useChannelStore = create<ChannelStore>((set, get) => ({
   channels: [],
+  refetch: false,
   setChannel: (channelId: string, name: string) =>
     set((state): ChannelStore | Partial<ChannelStore> => ({
       channels: [

--- a/src/stores/messageStore.ts
+++ b/src/stores/messageStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+type MessageStore = {
+  refetch: boolean;
+  setRefetch: () => void;
+};
+export const useMessageStore = create<MessageStore>((set) => ({
+  refetch: false,
+  setRefetch: () =>
+    set((state) => ({
+      refetch: !state.refetch,
+    })),
+}));


### PR DESCRIPTION
메세지 전송하면 리스트에 바로 렌더링 되게 전역 상태 설정하여 fetch 변경
팔로우 카드에서 쪽지 보내기 클릭시 이동 경로값 수정
메세지 textarea enter키 버그 수정