### PR TITLE
fix: 알림창 유저이름 수정

### DIFF
--- a/src/components/Header/HeaderIcon.tsx
+++ b/src/components/Header/HeaderIcon.tsx
@@ -19,7 +19,11 @@ export type Boxtype = "userMenu" | "notice" | "search" | null;
 export type Alert = {
   _id: string;
   seen: boolean;
-  author: BaseUser;
+  author: {
+    _id: string;
+    username: string;
+    fullname: string;
+  };
   user: BaseUser;
   post: string;
   like?: {

--- a/src/components/Header/NoticeBox.tsx
+++ b/src/components/Header/NoticeBox.tsx
@@ -24,7 +24,7 @@ export default function NoticeBox({
   const getAlertMessage = (a: Alert) => {
     if (!a) return;
     if (a.author._id === myId) return;
-    const sender = a.username;
+    const sender = a.author.username ? a.author.username : "익명의 유저";
 
     if (a.message) return `${sender}님이 쪽지를 보냈습니다.`;
     if (a.follow) return `${sender}님이 당신을 팔로우 했습니다.`;
@@ -38,8 +38,6 @@ export default function NoticeBox({
     const prev = JSON.parse(localStorage.getItem("alertId") || "[]");
     const updated = [...new Set([...prev, alert._id])];
     localStorage.setItem("alertId", JSON.stringify(updated));
-    console.log(prev);
-    console.log(updated);
     setAlerts((prev) => prev.map((a) => (a._id === alert._id ? { ...a, seen: true } : a)));
 
     if (alert.message) {


### PR DESCRIPTION
알림창 유저 닉네임 표시.
닉네임 설정하지 않은 경우 "익명의 유저"라고 표시됨
